### PR TITLE
ansible: do not mount the rbd image and CephFs

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -19,6 +19,19 @@
   roles:
     - ceph-admin
 
+- hosts: ceph_nodes
+  gather_facts: false
+  become: true
+  any_errors_fatal: true
+  tasks:
+    - name: Create mount directories for rbd and cephfs
+      file:
+        path: "{{ item }}"
+        state: directory
+      with_items:
+        - "/mnt/rbd"
+        - "/mnt/cephfs"
+
 - hosts: ceph_nodes[0]
   gather_facts: false
   become: true
@@ -35,24 +48,10 @@
         - ceph osd pool create cephfs-datapool 64
         - ceph osd pool create cephfs-metapool 32
         - ceph fs new cephfs cephfs-metapool cephfs-datapool
-    - name: Check ceph health status
-      command: ceph --status
-      register: status
-    - debug:
-        msg:
-          - "# ceph --status"
-          - "{{ status.stdout_lines }}"
-
-- hosts: ceph_nodes[0]
-  gather_facts: false
-  become: true
-  any_errors_fatal: true
-  tasks:
     - name: Creating an image file in rbd block pool and map
       command: "{{ item }}"
       with_items:
         - rbd create --size 1024 rbd-pool/image1 --image-feature layering
-        - rbd device map rbd-pool/image1
     - name: Check rbd image info
       command: rbd info rbd-pool/image1
       register: rbd_info
@@ -60,35 +59,6 @@
         msg:
           - "# rbd info rbd-pool/image1"
           - "{{ rbd_info.stdout_lines }}"
-    - name: create rbd mount directory
-      file:
-        path: "/mnt/rbd"
-        state: directory
-    - name: Format the block device with ext4
-      command: mkfs.ext4 /dev/rbd0
-      register: mkfs
-    - debug:
-        msg:
-          - "# mkfs.ext4 /dev/rbd0"
-          - "{{ mkfs.stdout_lines }}"
-    - name: Mount the /dev/rbd0 to /mnt/rbd/
-      mount:
-        path: /mnt/rbd/
-        src: /dev/rbd0
-        fstype: ext4
-        state: mounted
-    - name: Check the rbd block volume mount status
-      shell: df -Th | grep -e Filesystem -e rbd0
-      register: df_blk
-    - debug:
-        msg:
-          - "# df -Th"
-          - "{{ df_blk.stdout_lines }}"
-    - name: Get the secret
-      shell: "{{ item }}"
-      register: secret
-      with_items:
-        - ceph-authtool -p /etc/ceph/ceph.client.admin.keyring
     - name: Check ceph fs status
       command: ceph fs status
       register: cephfs_status
@@ -96,40 +66,43 @@
         msg:
           - "# ceph fs status"
           - "{{ cephfs_status.stdout_lines }}"
-    - name: create cephfs mount directory
-      file:
-        path: "/mnt/cephfs"
-        state: directory
-    - name: Mount the ceph fs to /mnt/cephfs
-      mount:
-        path: /mnt/cephfs/
-        src: "{{ groups['ceph_nodes'][0] }}:6789:/"
-        fstype: ceph
-        opts: "name=admin,secret={{ secret.results[0].stdout }}"
-        state: mounted
-    - name: Check the ceph fs volume mount status
-      shell: 'df -Th | grep -e Filesystem -e ceph'
-      register: df_fs
+    - name: Check ceph health status
+      command: ceph --status
+      register: status
     - debug:
         msg:
-          - "# df -Th"
-          - "{{ df_fs.stdout_lines }}"
+          - "# ceph --status"
+          - "{{ status.stdout_lines }}"
     - name: Get cluster ID
       command: "ceph fsid"
       register: fsid
-    - name: Get admin key
-      command: "ceph auth print-key client.admin"
-      register: admin_key
     - name: Get mon ips
       shell: "ceph mon metadata | grep addrs | cut -d':' -f3"
       register: mon_ips
+    - name: Get the secret
+      command: "ceph-authtool -p /etc/ceph/ceph.client.admin.keyring"
+      register: secret
     - debug:
         msg:
-          - "--------------- Details of ceph cluster ------------"
-          - "* Cluster ID:"
-          - "{{ fsid.stdout_lines }}"
-          - "* Admin Key:"
-          - "{{ admin_key.stdout_lines }}"
-          - "* Mon IPs:"
-          - "{{ mon_ips.stdout_lines }}"
+          - "--------------- CEPH CLUSTER SUMMARY  ------------"
+          - "❇ Cluster ID: "
+          - "    {{ fsid.stdout_lines[0] }} "
+          - "❇ Mon IPs: "
+          - "    {{ mon_ips.stdout_lines }} "
+          - "❇ Admin Key:"
+          - "    {{ secret.stdout_lines[0] }} "
+          - ""
+          - "❇ Rbd pool name: "
+          - "    rbd-pool "
+          - "❇ To mount the precreated rbd image, run: "
+          - "    # vagrant ssh <{{ groups['ceph_nodes'] | join('|') }}> "
+          - "    # sudo rbd device map rbd-pool/image1 "
+          - "    # sudo mkfs.ext4 /dev/rbd0 "
+          - "    # sudo mount /dev/rbd0 /mnt/rbd "
+          - ""
+          - "❇ Ceph FS name: "
+          - "    cephfs "
+          - "❇ To mount the ceph fs, run:"
+          - "    # vagrant ssh <{{ groups['ceph_nodes'] | join('|') }}> "
+          - "    # sudo mount -t ceph {{ groups['ceph_nodes'][0] }}:6789:/ /mnt/cephfs -o name=admin,secret='{{ secret.stdout_lines[0] }}' "
           - "----------------------------------------------------"


### PR DESCRIPTION
Because of this, on reboot ceph-node1 hangs.
Rather, give instructions to mount both rbd image and CephFs in summary.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>